### PR TITLE
Specified redcarpet version in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source "http://rubygems.org"
 gem "rack"
 gem "sinatra", ">=1.3"
 gem "shotgun"
-gem "redcarpet"
+gem 'redcarpet', '1.17.2'
 gem "rspec"
 gem "rack-test"


### PR DESCRIPTION
Commonplace doesn't work with redcarpet 2.0 and higher, specified newest version that works.
